### PR TITLE
Adds initial components to recreate resume

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 .App {
-  text-align: center;
+  text-align: left;
 }
 
 .App-logo {
@@ -20,7 +20,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
+  font-size: "10pt";
   color: white;
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,27 +1,33 @@
 import React from 'react';
-import logo from './logo.svg';
 import './App.css';
+import './resume.css'
+import { Personal } from './components/personal/Personal';
+import { Education } from './components/education/Education';
+import { Experience } from './components/experience/Experience';
+import { Skills } from './components/skills/Skills';
+import { Section } from './components/Section';
 
-function App(props) {
+function App({resume}) {
+  const experience = resume.experience.map(experience => 
+    <Experience experience={experience}/>
+  )
+  const education = resume.education.map(education => 
+    <Education education={education}/>
+  )
   return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <p>
-          {props.resume}
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+    <div className='App'>
+      <div style={{width: '100%'}}>
+        <Personal personal={resume.personal} />
+        <Section title='Education'>
+          {education}
+        </Section>
+        <Section title='Experience'>
+          {experience}
+        </Section>
+        <Section title='Computer Skills'>
+          <Skills skills={resume.skills} />
+        </Section>
+      </div>
     </div>
   );
 }

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+type SectionProps = {
+    title: string
+}
+
+export const Section: React.FC<SectionProps> = (props) => {
+  return (
+    <div className='Section'>
+      <span className='Title'>
+        {props.title}
+      </span>
+      <hr />
+      {props.children}
+    </div>
+  )
+}

--- a/src/components/education/Degree.tsx
+++ b/src/components/education/Degree.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import * as ResumeTypes from '../../resumeTypes';
+
+type DegreeProps = {
+  degree: ResumeTypes.Degree
+}
+
+export const Degree: React.FC<DegreeProps> = ({degree}) => (
+  <div className='Degree twoColumn'>
+    <span>
+      {degree.level} in {degree.subject}
+    </span>
+    <span>
+      {degree.obtained}
+    </span>
+  </div>
+)

--- a/src/components/education/Education.tsx
+++ b/src/components/education/Education.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import * as ResumeTypes from '../../resumeTypes';
+import { Degree } from './Degree';
+
+type EducationProps = {
+    education: ResumeTypes.Education
+}
+
+export const Education: React.FC<EducationProps> = ({education}) => {
+  const degrees = education.degrees.map(degree => (
+    <Degree degree={degree} />
+  ))
+  return (
+    <div className='Education'>
+      <span className='School'>
+        {education.school}, {education.location}
+      </span>
+      {degrees}
+    </div>
+  )
+}

--- a/src/components/experience/Experience.tsx
+++ b/src/components/experience/Experience.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import * as ResumeTypes from '../../resumeTypes';
+import { ExperiencePosition } from './ExperiencePosition';
+
+type ExperienceProps = {
+  experience: ResumeTypes.Experience
+}
+
+export const Experience: React.FC<ExperienceProps> = ({experience}) => {
+  const positions = experience.positions.map(position => (
+    <ExperiencePosition position={position}/>
+  ))
+  
+  return (
+    <div style={{marginBottom: '1em'}}>
+      <div className='twoColumn'>
+        <span style={{fontWeight: 'bold'}}>
+          {experience.company}
+        </span>
+        <span>
+          {experience.location}
+        </span>
+      </div>  
+      <div>
+        {positions}
+      </div>
+    </div>
+  )
+}

--- a/src/components/experience/ExperiencePosition.tsx
+++ b/src/components/experience/ExperiencePosition.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import * as ResumeTypes from '../../resumeTypes';
+
+type ExperiencePositionProps = {
+  position: ResumeTypes.ExperiencePosition
+}
+
+export const ExperiencePosition: React.FC<ExperiencePositionProps> = ({position}) => {
+  const accomplisments = position.accomplishments.map(accomplisment => (
+      <li>{accomplisment}</li>
+  ))
+
+  return (
+    <div>
+      <div className='twoColumn'>
+        <span>
+          {position.role}
+        </span>
+        <span>
+          {position.start} - {position.end || 'Present'}
+        </span>
+      </div>  
+      <ul style={{marginTop: '0.25em', marginBottom: '0.5em'}}>{accomplisments}</ul>
+    </div>
+  )
+}

--- a/src/components/personal/Personal.tsx
+++ b/src/components/personal/Personal.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import * as ResumeTypes from '../../resumeTypes';
+
+type PersonalProps = {
+  personal: ResumeTypes.Personal;
+}
+
+export const Personal: React.FC<PersonalProps> = ({personal}) => {
+  const { address } = personal;
+  const streetAddress = address.line1;
+  const cityStateZip = `${address.city}, ${address.state} ${address.zip}`;
+
+  return (
+    <div className='Personal'>
+      <div className='Name'>
+        {personal.name}
+      </div>
+      <div className='twoColumn'>
+        <span>
+          {streetAddress} <br/>
+          {cityStateZip}
+        </span>
+        <span>
+          {personal.email}<br/>
+          {personal.phone}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/skills/Skills.tsx
+++ b/src/components/skills/Skills.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+type SkillsProps = {
+  skills: any;
+}
+
+export const Skills: React.FC<SkillsProps> = (props) => {
+  const skills = Object.entries(props.skills).map(([skill, values]) => (
+    <div>
+      <b>{skill}</b> - {(values as string[]).join(', ')}
+    </div>
+  ));
+
+  return (
+    <div className='Skills'>
+      {skills}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,13 +1,7 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Georgia', 'serif';
+  font-size: 10pt;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import Resume from './resume';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App resume={JSON.stringify(Resume, null, 2)}/>
+    <App resume={Resume}/>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/src/resume.css
+++ b/src/resume.css
@@ -1,0 +1,40 @@
+@media print{
+    @page {
+        size: letter;
+        margin: 2cm;
+    }
+}
+
+.Personal .Name {
+    font-size: 16pt;
+    font-weight: bold;
+    width: 100%;
+    text-align: center;
+}
+
+.Section {
+    margin-top: 1em;
+}
+
+.Section .Title {
+    font-size: 14pt;
+    font-weight: bold;
+    width: 100%;
+}
+
+.Section hr {
+    border: 1px solid black;
+}
+
+.twoColumn {
+    display: flex
+}
+
+.twoColumn span:nth-child(1) {
+    width: 100%;
+}
+
+.twoColumn span:nth-child(2) {
+    width: 100%;
+    text-align: right;
+}

--- a/src/resume.ts
+++ b/src/resume.ts
@@ -40,7 +40,8 @@ export default {
                start: 'November 2019',
                accomplishments: [
                   'Released a Fitbit version of the LIFE Extend mobile app',
-                  'Contributed to open source projects '
+                  'Contributed to open source projects.',
+                  'Generated this resume as a React app.'
                ]
             },
             {
@@ -115,19 +116,19 @@ export default {
       }
    ],
    skills: {
-      languages: [
+      'Languages': [
          'Javascript/Typescript',
          'Java',
          'C/C++',
          'Python'
       ],
-      platforms: [
+      'Platforms': [
          'OS X',
          'Ubuntu',
          'Solaris',
          'Windows'
       ],
-      additional: [
+      'Additional Skills': [
          'AWS',
          'Scrum',
          'Git',

--- a/src/resumeTypes.ts
+++ b/src/resumeTypes.ts
@@ -7,9 +7,17 @@ export interface Resume {
 
 export interface Personal {
     name: string;
-    address: any;
+    address: Address;
     email: string;
     phone: string;
+}
+
+export interface Address {
+    line1: string;
+    line2?: string;
+    city: string;
+    state: string;
+    zip: string;
 }
 
 export interface Education {


### PR DESCRIPTION
This introduces the basic components rendering the types from the previous PR.  The styling, both inline and in separate style sheets, was meant to make the print view of the app match my existing resume template.  Expanding design styles and options will be handled at a later time.